### PR TITLE
Use path filters

### DIFF
--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -2,37 +2,14 @@
 name: JSON
 
 "on":
+  push:
+    branches:
+      - main
   pull_request:
+    paths:
+      - "**.json"
 
 jobs:
-  filter:
-    name: Changed files
-    runs-on: ubuntu-latest
-
-    outputs:
-      changed: ${{ steps.changed-files.outputs.any_changed }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v34
-        with:
-          files: |
-            **/*.json
-
-      - name: List all changed files
-        run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            echo "$file"
-          done
-
   style:
     name: Style
-
-    needs: filter
-
     uses: ./.github/workflows/json-style.yml
-    if: ${{ needs.filter.outputs.changed == 'true' }}

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -2,44 +2,18 @@
 name: Markdown
 
 "on":
+  push:
+    branches:
+      - main
   pull_request:
+    paths:
+      - "**.md"
 
 jobs:
-  filter:
-    name: Changed files
-    runs-on: ubuntu-latest
-
-    outputs:
-      changed: ${{ steps.changed-files.outputs.any_changed }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v34
-        with:
-          files: "**/*.md"
-
-      - name: List all changed files
-        run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            echo "$file"
-          done
-
   lint:
     name: Lint
-
-    needs: filter
-
     uses: ./.github/workflows/markdown-lint.yml
-    if: ${{ needs.filter.outputs.changed == 'true' }}
 
   style:
     name: Style
-
-    needs: filter
-
     uses: ./.github/workflows/markdown-style.yml
-    if: ${{ needs.filter.outputs.changed == 'true' }}

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -12,16 +12,8 @@ name: Shell
 jobs:
   lint:
     name: Lint
-
-    needs: filter
-
     uses: ./.github/workflows/shell-lint.yml
-    if: ${{ needs.filter.outputs.changed == 'true' }}
 
   style:
     name: Style
-
-    needs: filter
-
     uses: ./.github/workflows/shell-style.yml
-    if: ${{ needs.filter.outputs.changed == 'true' }}

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -2,46 +2,19 @@
 name: YAML
 
 "on":
+  push:
+    branches:
+      - main
   pull_request:
+    paths:
+      - "**.yml"
+      - "**.yaml"
 
 jobs:
-  filter:
-    name: Changed files
-    runs-on: ubuntu-latest
-
-    outputs:
-      changed: ${{ steps.changed-files.outputs.any_changed }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v34
-        with:
-          files: |
-            **/*.yml
-            **/*.yaml
-
-      - name: List all changed files
-        run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            echo "$file"
-          done
-
   lint:
     name: Lint
-
-    needs: filter
-
     uses: ./.github/workflows/yaml-lint.yml
-    if: ${{ needs.filter.outputs.changed == 'true' }}
 
   style:
     name: Style
-
-    needs: filter
-
     uses: ./.github/workflows/yaml-style.yml
-    if: ${{ needs.filter.outputs.changed == 'true' }}


### PR DESCRIPTION
The previous iteration of the workflows has been changed to use path filters instead of an action to detect which files have changed. The action failed when no file matched its filter, which might happen with the setup that I have in mind. Path filter work more reliable, but will prevent me from requiring certain checks for pull requests.