### PR TITLE
Create GitHub Action to sync labels

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -1,0 +1,12 @@
+---
+name: GitHub
+
+"on":
+  push:
+    branches:
+      - main
+
+jobs:
+  labels:
+    name: Labels
+    uses: ./.github/workflows/sync-labels.yml

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,21 @@
+---
+name: Labels
+
+"on":
+  workflow_call:
+
+jobs:
+  labels:
+    name: Sync labels
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Sync labels
+        uses: micnncim/action-label-syncer@v1.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manifest: .github/labels.yml


### PR DESCRIPTION
Labels are managed through a configuration file in the repository. A new GitHub Action has been added that reads the labels from a file and syncs them to the repository.