### PR TITLE
Filter workflows that run on main branch

### DIFF
--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -5,6 +5,8 @@ name: JSON
   push:
     branches:
       - main
+    paths:
+      - "**.json"
   pull_request:
     paths:
       - "**.json"

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -5,6 +5,8 @@ name: Markdown
   push:
     branches:
       - main
+    paths:
+      - "**.md"
   pull_request:
     paths:
       - "**.md"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,9 @@ name: Rust
   push:
     branches:
       - main
+    paths:
+      - "**.rs"
+      - "**.toml"
   pull_request:
     paths:
       - "**.rs"

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -5,6 +5,8 @@ name: Shell
   push:
     branches:
       - main
+    paths:
+      - "**.sh"
   pull_request:
     paths:
       - "**.sh"

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -5,6 +5,9 @@ name: YAML
   push:
     branches:
       - main
+    paths:
+      - "**.yml"
+      - "**.yaml"
   pull_request:
     paths:
       - "**.yml"


### PR DESCRIPTION
By default, all workflows are run when code is pushed to the `main` branch. But since not every programming language will be used in a given repository, we still want to limit the runs by their path.