### PR TITLE
Add labels for GitHub

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,46 @@
+---
+- name: C-bug
+  color: e74c3c
+  description: "Report a new bug"
+- name: C-dependency
+  color: e74c3c
+  description: "Change or update a dependency"
+- name: C-documentation
+  color: e74c3c
+  description: "Improve the documentation"
+- name: C-feature-request
+  color: e74c3c
+  description: "Request a new feature"
+- name: L-github
+  color: 34495e
+  description: "Tag the GitHub ecosystem"
+- name: L-rust
+  color: 34495e
+  description: "Tag the Rust ecosystem"
+- name: PR-block
+  color: 3498db
+  description: "Do not merge the pull request"
+- name: PR-merge
+  color: 3498db
+  description: "Merge pull request when checks passed"
+- name: R-added
+  color: 95a5a6
+  description: "Add a new feature to the release notes"
+- name: R-changed
+  color: 95a5a6
+  description: "Add a change in existing functionality to the release notes"
+- name: R-deprecated
+  color: 95a5a6
+  description: "Add a soon-to-be removed feature to the release notes"
+- name: R-fixed
+  color: 95a5a6
+  description: "Add a fixed bug to the release notes"
+- name: R-ignore
+  color: 95a5a6
+  description: "Do not add this pull request to the release notes"
+- name: R-removed
+  color: 95a5a6
+  description: "Add a now removed feature to the release notes"
+- name: R-security
+  color: 95a5a6
+  description: "Add a vulnerability warning to the release notes"


### PR DESCRIPTION
The configuration file with a default set of labels has been copied over from my template repository [^1].

[^1]: https://github.com/jdno/template