### PR TITLE
Update GitHub Actions with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+---
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - jdno
+    reviewers:
+      - jdno
+    labels:
+      - C-dependency
+      - L-github
+      - R-ignore


### PR DESCRIPTION
Automatic updates for GitHub Actions have been enabled. Dependabot will check weekly if any action has a new version, and if so will create a pull request to update it.