### PR TITLE
Run Cargo in Rust actions directly

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -24,7 +24,4 @@ jobs:
         uses: swatinem/rust-cache@v2.2.0
 
       - name: Run Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/rust-style.yml
+++ b/.github/workflows/rust-style.yml
@@ -21,7 +21,4 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run Rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check


### PR DESCRIPTION
Instead of invoking Cargo through the unmaintained [actions-rs/cargo] action, it is now run straight as a shell command.

[actions-rs/cargo]: https://github.com/actions-rs/cargo