### PR TITLE
Install the OpenSSL headers

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install OpenSSL headers
+        run: sudo apt-get install libssl-dev
+
       - name: Checkout code
         uses: actions/checkout@v3
 


### PR DESCRIPTION
The latest versions of rustls require the OpenSSL headers for its compilation. Since it is included in more and more crates, we have opted to install it by default.