### PR TITLE
Remove deprecated set-output command

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -34,11 +34,11 @@ jobs:
         id: coverage
         run: |
           if [[ "${{ secrets.CODECOV_TOKEN }}" != "" ]]; then
-            echo "Enable collection of test coverage"
-            echo "::set-output name=enable::true"
+            echo "Run tests with test coverage"
+            echo "{enable}={true}" >> $GITHUB_OUTPUT
           else
             echo "Run tests without coverage"
-            echo "::set-output name=enable::false"
+            echo "{enable}={false}" >> $GITHUB_OUTPUT
           fi
 
       - name: Run tests


### PR DESCRIPTION
GitHub has deprecated the `set-output` command.[^1] It has been replaced by an environment file, into which the output has to be written.

[^1]: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/