### PR TITLE
Run Rust actions in pre-built containers

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,46 @@
+---
+name: Docker
+
+"on":
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build and push
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        dockerfile:
+          - Dockerfile.rust
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get image name from Dockerfile name
+        id: name
+        run: |
+          image_name=$(echo ${{ matrix.dockerfile }} | cut -d '.' -f 2)
+          echo "image_name=$image_name" >> $GITHUB_OUTPUT
+          echo "$image_name"
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ steps.name.outputs.image_name }}:latest

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -13,15 +13,12 @@ jobs:
     name: Lint code
     runs-on: ubuntu-latest
 
-    steps:
-      - name: Install OpenSSL headers
-        run: sudo apt-get install libssl-dev
+    container:
+      image: ghcr.io/jdno/rust:latest
 
+    steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache build artifacts
         uses: swatinem/rust-cache@v2.2.0

--- a/.github/workflows/rust-style.yml
+++ b/.github/workflows/rust-style.yml
@@ -13,12 +13,12 @@ jobs:
     name: Check style
     runs-on: ubuntu-latest
 
+    container:
+      image: ghcr.io/jdno/rust:latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
 
       - name: Run Rustfmt
         run: cargo fmt --all -- --check

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Cache build artifacts
         uses: swatinem/rust-cache@v2.2.0
 

--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -1,0 +1,4 @@
+FROM rust:1.66.1
+
+# Install Clippy and rustfmt
+RUN rustup component add clippy rustfmt


### PR DESCRIPTION
Instead of running Rust actions in the default Ubuntu runner, which requires us to install Rust manually, we are instead choosing to run the actions in a pre-built Docker container. The container is built from the official Rust container[^1], but contains some additional tools used in tests.

[^1]: https://hub.docker.com/_/rust