### PR TITLE
Install clang in Docker image for Rust

### DIFF
--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -1,4 +1,8 @@
 FROM rust:1.66.1
 
+RUN apt-get update && apt-get install -y \
+    clang \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install Clippy and rustfmt
 RUN rustup component add clippy rustfmt


### PR DESCRIPTION
The `gdnative-sys` crate that we use in `auto-traffic-control-ui` requires `libclang` to compile.