### PR TITLE
Instal clang in test environment for Rust

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Install system dependencies
+        run: |
+          apt-get update
+          apt-get install -y clang
+
       - name: Cache build artifacts
         uses: swatinem/rust-cache@v2.2.0
 


### PR DESCRIPTION
Tests for Rust are run in a different Docker container, which needs clang as well.