### PR TITLE
Install Protobuf compiler for Rust

### DIFF
--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -2,6 +2,7 @@ FROM rust:1.66.1
 
 RUN apt-get update && apt-get install -y \
     clang \
+    protoc \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Clippy and rustfmt


### PR DESCRIPTION
Some of my projects are using gRPC and Protocol Buffers, for which the protoc compiler is added to the base image.