### PR TITLE
Reference Docker image by branch name

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/jdno/rust:latest
+      image: ghcr.io/jdno/rust:main
 
     steps:
       - name: Checkout code

--- a/.github/workflows/rust-style.yml
+++ b/.github/workflows/rust-style.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/jdno/rust:latest
+      image: ghcr.io/jdno/rust:main
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The workflows now use the Docker image that is tagged with the name of the default branch. This provides a more robust solution and allows easier iteration on other branches.