### PR TITLE
Install alsa for Rust

### DIFF
--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -2,6 +2,7 @@ FROM rust:1.66.1
 
 RUN apt-get update && apt-get install -y \
     clang \
+    libasound2 \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Some Rust projects work with sounds, for which they need the alsa sound library installed in the system.