### PR TITLE
Assign dependecy updates to @jdno

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":disableDependencyDashboard"],
+
+  "assignees": ["jdno"],
+  "reviewers": ["jdno"],
   "semanticCommits": "disabled"
 }


### PR DESCRIPTION
When a pull request is created to update a dependency, we want to assign it to @jdno so that it shows up more prominently in the notifications.