### PR TITLE
Fix checking the style of Terraform files

### DIFF
--- a/.github/workflows/terraform-style.yml
+++ b/.github/workflows/terraform-style.yml
@@ -25,4 +25,4 @@ jobs:
 
       - name: Run terraform fmt
         working-directory: ${{ inputs.path }}
-        run: terraform fmt -recursive .
+        run: terraform fmt -check -recursive .


### PR DESCRIPTION
The style check for Terraform files has been fixed. Previously, it would just reformat the files without failing the test.