### PR TITLE
Add no-op status checks

### DIFF
--- a/.github/workflows/ansible-noop.yml
+++ b/.github/workflows/ansible-noop.yml
@@ -1,0 +1,16 @@
+---
+name: Ansible
+
+"on":
+  pull_request:
+    paths-ignore:
+      - "ansible"
+
+jobs:
+  lint:
+    name: Lint / Lint code
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip check
+        run: echo "No matching files - skipping check"

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -1,0 +1,19 @@
+---
+name: Ansible
+
+"on":
+  push:
+    branches:
+      - main
+    paths:
+      - "ansible/**"
+  pull_request:
+    paths:
+      - "ansible/**"
+
+jobs:
+  lint:
+    name: Lint
+    uses: ./.github/workflows/ansible-lint.yml
+    with:
+      path: "ansible"

--- a/.github/workflows/json-noop.yml
+++ b/.github/workflows/json-noop.yml
@@ -1,0 +1,16 @@
+---
+name: JSON
+
+"on":
+  pull_request:
+    paths-ignore:
+      - "**.json"
+
+jobs:
+  style:
+    name: Style / Check style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip check
+        run: echo "No matching files - skipping check"

--- a/.github/workflows/markdown-noop.yml
+++ b/.github/workflows/markdown-noop.yml
@@ -1,0 +1,24 @@
+---
+name: Markdown
+
+"on":
+  pull_request:
+    paths-ignore:
+      - "**.md"
+
+jobs:
+  lint:
+    name: Lint / Lint code
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip check
+        run: echo "No matching files - skipping check"
+
+  style:
+    name: Style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip check
+        run: echo "No matching files - skipping check"

--- a/.github/workflows/rust-noop.yml
+++ b/.github/workflows/rust-noop.yml
@@ -1,0 +1,33 @@
+---
+name: Rust
+
+"on":
+  pull_request:
+    paths-ignore:
+      - "**.rs"
+      - "**.toml"
+
+jobs:
+  lint:
+    name: Lint / Lint code
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip check
+        run: echo "No matching files - skipping check"
+
+  style:
+    name: Style / Check style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip check
+        run: echo "No matching files - skipping check"
+
+  test:
+    name: Test / Run tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip check
+        run: echo "No matching files - skipping check"

--- a/.github/workflows/shell-noop.yml
+++ b/.github/workflows/shell-noop.yml
@@ -1,0 +1,24 @@
+---
+name: Shell
+
+"on":
+  pull_request:
+    paths-ignore:
+      - "**.sh"
+
+jobs:
+  lint:
+    name: Lint / Lint code
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip check
+        run: echo "No matching files - skipping check"
+
+  style:
+    name: Style / Check style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip check
+        run: echo "No matching files - skipping check"

--- a/.github/workflows/typescript-noop.yml
+++ b/.github/workflows/typescript-noop.yml
@@ -1,0 +1,34 @@
+---
+name: TypeScript
+
+"on":
+  pull_request:
+    paths-ignore:
+      - "package.json"
+      - "package-lock.json"
+      - "**.ts"
+
+jobs:
+  lint:
+    name: Lint / Lint code
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip check
+        run: echo "No matching files - skipping check"
+
+  style:
+    name: Style / Check style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip check
+        run: echo "No matching files - skipping check"
+
+  test:
+    name: Test / Run tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip check
+        run: echo "No matching files - skipping check"

--- a/.github/workflows/yaml-noop.yml
+++ b/.github/workflows/yaml-noop.yml
@@ -1,0 +1,25 @@
+---
+name: YAML
+
+"on":
+  pull_request:
+    paths-ignore:
+      - "**.yml"
+      - "**.yaml"
+
+jobs:
+  lint:
+    name: Lint / Lint code
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip check
+        run: echo "No matching files - skipping check"
+
+  style:
+    name: Style / Check style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Skip check
+        run: echo "No matching files - skipping check"


### PR DESCRIPTION
Required status checks require that every status is reported with as a "success". This doesn't work with path filters, which will not report a status at all. The official recommendation[^1] is to create a no-op status check that has the inverse of the path filter so that a status gets reported.

[^1]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks