### PR TITLE
Escape GitHub variables in Liquid template

### DIFF
--- a/rust/test.yml
+++ b/rust/test.yml
@@ -30,7 +30,7 @@ test:
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v3
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: {{ '${{ secrets.CODECOV_TOKEN }}' }}
 
     - name: Archive code coverage results
       uses: actions/upload-artifact@v3

--- a/rust/workflow.yml
+++ b/rust/workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      any_changed: ${{ steps.detect-changes.outputs.any_changed }}
+      any_changed: {{ '${{ steps.detect-changes.outputs.any_changed }}' }}
 
     steps:
       - name: Checkout code
@@ -33,8 +33,10 @@ jobs:
 
       - name: Print changed files
         run: |
-          for file in ${{ steps.changed-files-specific.outputs.all_changed_files }}; do
+          for file in {{ '${{ steps.changed-files-specific.outputs.all_changed_files }}' }}; do
             echo "$file"
           done
 
-  {{jobs}}
+  {%- for job in jobs %}
+  {{ job }}
+  {% endfor -%}


### PR DESCRIPTION
The syntax that GitHub uses to inject variables into workflow definitions breaks rendering the Liquid templates, because `${{` gets interpreted as an opening bracket in the template. As a quick workaround, we are emitting variables in the templates as a string in a Liquid expression.