### PR TITLE
Revert Liquid templating

### DIFF
--- a/rust/test.yml
+++ b/rust/test.yml
@@ -30,7 +30,7 @@ test:
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v3
       with:
-        token: {{ '${{ secrets.CODECOV_TOKEN }}' }}
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Archive code coverage results
       uses: actions/upload-artifact@v3

--- a/rust/workflow.yml
+++ b/rust/workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      any_changed: {{ '${{ steps.detect-changes.outputs.any_changed }}' }}
+      any_changed: ${{ steps.detect-changes.outputs.any_changed }}
 
     steps:
       - name: Checkout code
@@ -33,10 +33,6 @@ jobs:
 
       - name: Print changed files
         run: |
-          for file in {{ '${{ steps.changed-files-specific.outputs.all_changed_files }}' }}; do
+          for file in ${{ steps.changed-files-specific.outputs.all_changed_files }}; do
             echo "$file"
           done
-
-  {%- for job in jobs %}
-  {{ job }}
-  {% endfor -%}


### PR DESCRIPTION
The previous commit escaped GitHub's variable syntax to make it compatible with the Liquid template engine. This change is being reverted, since FlowCrafter is no longer using Liquid to render workflows.

This reverts commit 207bf524c43a29f71b61a3a313feb81a170674eb.