### PR TITLE
Add workflow to test feature flags in Rust

### DIFF
--- a/rust/features.yml
+++ b/rust/features.yml
@@ -1,0 +1,22 @@
+features:
+  name: Test feature flags
+  runs-on: ubuntu-latest
+
+  needs: detect-changes
+  if: needs.detect-changes.outputs.any_changed == 'true'
+
+  container:
+    image: ghcr.io/jdno/rust:main
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Cache build artifacts
+      uses: swatinem/rust-cache@v2.2.1
+
+    - name: Install cargo-all-features
+      run: cargo install cargo-all-features
+
+    - name: Test all feature flag combinations
+      run: cargo test-all-features


### PR DESCRIPTION
Crates in Rust can have optional features and dependencies, which can interact with each other in unintended ways. To avoid this, the tool cargo-all-features tests all permutations of a crate's features.