### PR TITLE
Create FlowCrafter template for GitHub maintenance

### DIFF
--- a/github/sync-labels.yml
+++ b/github/sync-labels.yml
@@ -1,0 +1,14 @@
+labels:
+  name: Sync labels
+  runs-on: ubuntu-latest
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Sync labels
+      uses: micnncim/action-label-syncer@v1.3.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        manifest: .github/labels.yml

--- a/github/workflow.yml
+++ b/github/workflow.yml
@@ -1,0 +1,7 @@
+---
+name: GitHub
+
+"on":
+  push:
+    branches:
+      - main


### PR DESCRIPTION
A new FlowCrafter template has been created to manage a GitHub repository through GitHub Actions. The only available job is to sync labels from a configuration file inside the repository.