### PR TITLE
Add job to test TypeScript projects

### DIFF
--- a/typescript/test.yml
+++ b/typescript/test.yml
@@ -1,0 +1,22 @@
+test:
+  name: Run tests
+  runs-on: ubuntu-latest
+
+  needs: detect-changes
+  if: needs.detect-changes.outputs.any_changed == 'true'
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Node
+      uses: actions/setup-node@v3.6.0
+      with:
+        cache: npm
+        node-version: 16
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run tests
+      run: npm test


### PR DESCRIPTION
The workflow to test TypeScript projects has added as a FlowCrafter template. It was accidentally left out when migrating the shared workflows.