### PR TITLE
Enable automatic dependency updates for workflows

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,22 @@
 
   "assignees": ["jdno"],
   "reviewers": ["jdno"],
-  "semanticCommits": "disabled"
+
+  "labels": ["C-dependency"],
+  "semanticCommits": "disabled",
+
+  "github-actions": {
+    "fileMatch": [
+      "ansible/*.yml",
+      "github/*.yml",
+      "json/*.yml",
+      "markdown/*.yml",
+      "rust/*.yml",
+      "shell/*.yml",
+      "terraform/*.yml",
+      "typescript/*.yml",
+      "yaml/*.yml"
+    ],
+    "labels": ["L-github"]
+  }
 }


### PR DESCRIPTION
Renovate has been configured to check the templates for updates as well. The different template folders are currently hard-coded in the configuration file to ensure that updates work, but we might refactor this later to be more dynamic and less error-prone.