### PR TITLE
Update fragments with Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,18 +8,16 @@
   "labels": ["C-dependency"],
   "semanticCommits": "disabled",
 
-  "github-actions": {
-    "fileMatch": [
-      "ansible/*.yml",
-      "github/*.yml",
-      "json/*.yml",
-      "markdown/*.yml",
-      "rust/*.yml",
-      "shell/*.yml",
-      "terraform/*.yml",
-      "typescript/*.yml",
-      "yaml/*.yml"
-    ],
-    "labels": ["L-github"]
-  }
+  "pre-commit": {
+    "enabled": true
+  },
+
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^[\\w]+/*.yml$"],
+      "matchStrings": ["uses: (?<depName>.*?)@(?<currentValue>.*?)$"],
+      "datasourceTemplate": "github-releases"
+    }
+  ]
 }


### PR DESCRIPTION
Renovate provides a lot of options to customize its behavior. Custom managers in particular can be used to find dependencies using regex patterns. We use this approach to update the dependencies found in fragments, which are not fully valid GitHub Action workflows and thus not natively supported by Renovate.