### PR TITLE
Revert custom manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,16 +8,8 @@
   "labels": ["C-dependency"],
   "semanticCommits": "disabled",
 
-  "pre-commit": {
-    "enabled": true
-  },
-
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["^[\\w]+/*.yml$"],
-      "matchStrings": ["uses: (?<depName>.*?)@(?<currentValue>.*?)$"],
-      "datasourceTemplate": "github-releases"
-    }
-  ]
+  "github-actions": {
+    "fileMatch": ["^[\\w]+/*.yml"],
+    "labels": ["L-github"]
+  }
 }


### PR DESCRIPTION
The addition of a custom manager for fragments has not yielded the expected results, so we are reverting back to extending the builtin manager's file matches.