### PR TITLE
Fix regex for fragments

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
   "semanticCommits": "disabled",
 
   "github-actions": {
-    "fileMatch": ["^[\\w]+/*.yml"],
+    "fileMatch": ["^[\\w]+\\/[\\w]+\\.yml$"],
     "labels": ["L-github"]
   }
 }


### PR DESCRIPTION
The regex for fragments only matched the file name and not the full path, which led to no matches due to wrapping the regex with `^` and `$`.