### PR TITLE
Enable workflows to be triggered manually

### DIFF
--- a/.github/flowcrafter.yml
+++ b/.github/flowcrafter.yml
@@ -1,5 +1,21 @@
+# This file is managed by FlowCrafter. Manual changes will be overwritten
+# the next time you run FlowCrafter.
+---
 library:
-  github:
-    instance: https://api.github.com/
-    owner: jdno
-    repository: workflows
+  local:
+    path: .
+workflows:
+  - name: github
+    jobs:
+      - sync-labels
+  - name: json
+    jobs:
+      - style
+  - name: markdown
+    jobs:
+      - lint
+      - style
+  - name: yaml
+    jobs:
+      - lint
+      - style

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -5,6 +5,7 @@ name: GitHub
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   labels:
@@ -13,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v3
 
       - name: Sync labels
         uses: micnncim/action-label-syncer@v1.3.0

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -6,6 +6,7 @@ name: JSON
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:
@@ -17,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v4
 
       - name: Get changed files
         id: detect-changes
@@ -41,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v4
 
       - name: prettier
         uses: creyD/prettier_action@v4.3

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -6,6 +6,7 @@ name: Markdown
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:
@@ -17,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v4
 
       - name: Get changed files
         id: detect-changes
@@ -41,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v4
 
       - name: markdownlint-cli
         uses: nosborn/github-action-markdown-cli@v3.3.0
@@ -57,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v4
 
       - name: prettier
         uses: creyD/prettier_action@v4.3

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -6,6 +6,7 @@ name: YAML
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:
@@ -17,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v4
 
       - name: Get changed files
         id: detect-changes
@@ -42,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v4
 
       - name: Run yamllint
         uses: actionshub/yamllint@v1.8.2
@@ -56,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v4
 
       - name: prettier
         uses: creyD/prettier_action@v4.3

--- a/ansible/workflow.yml
+++ b/ansible/workflow.yml
@@ -6,6 +6,7 @@ name: Ansible
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:

--- a/github/workflow.yml
+++ b/github/workflow.yml
@@ -5,3 +5,4 @@ name: GitHub
   push:
     branches:
       - main
+  workflow_dispatch:

--- a/json/workflow.yml
+++ b/json/workflow.yml
@@ -6,6 +6,7 @@ name: JSON
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:

--- a/markdown/workflow.yml
+++ b/markdown/workflow.yml
@@ -6,6 +6,7 @@ name: Markdown
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:

--- a/rust/workflow.yml
+++ b/rust/workflow.yml
@@ -6,6 +6,7 @@ name: Rust
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 env:
   CARGO_INCREMENTAL: 0

--- a/shell/workflow.yml
+++ b/shell/workflow.yml
@@ -6,6 +6,7 @@ name: Shell
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:

--- a/terraform/workflow.yml
+++ b/terraform/workflow.yml
@@ -6,6 +6,7 @@ name: Terraform
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:

--- a/typescript/workflow.yml
+++ b/typescript/workflow.yml
@@ -6,6 +6,7 @@ name: TypeScript
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:

--- a/yaml/workflow.yml
+++ b/yaml/workflow.yml
@@ -6,6 +6,7 @@ name: YAML
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:


### PR DESCRIPTION
GitHub provides the `workflow_dispatch` trigger, which can be used to manually start a workflow from GitHub's user interface.