### PR TITLE
Switch to tagged version for GitHub Action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
A long time ago, probably by accident, the Docker workflow got changed to use a specific commit instead of a tagged version. This didn't cause any issues, but creates more noise since the commit changes more frequently then the tagged version.